### PR TITLE
fix: 변경된 파일이 없을 경우 husky pre commit 에러 수정 (ST-62)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -23,10 +23,12 @@ echo "$changed_files" | while IFS= read -r file; do
   fi
 done
 
-# 변경된 파일들을 다시 스테이징합니다.
-echo "$changed_files" | while IFS= read -r file; do
-  git add "$file"
-done
+# 변경된 파일들이 있을 경우, 다시 스테이징합니다.
+if [ -n "$changed_files" ]; then
+  echo "$changed_files" | while IFS= read -r file; do
+    git add "$file"
+  done
+fi
 
 if [ $? -ne 0 ]; then
   echo "에러 발생! 파일을 다시 스테이징하는 중 오류가 발생했습니다."


### PR DESCRIPTION
## #️⃣연관된 이슈

- ST-62

## 📝작업 내용

husky pre commit 수행 시 종종 이런 에러가 발생합니다.

```bash
lint 검사 및 format 수행 중...

> testrepo@0.1.0 lint C:\Users\int01\workspace\TravelMaker
> next lint

fatal: empty string is not a valid pathspec. please use . instead if you meant to match all paths
husky - pre-commit script failed (code 128)
```

husky pre commit 훅의 이 부분에서, 

```bash
# 변경된 파일들을 다시 스테이징합니다.
echo "$changed_files" | while IFS= read -r file; do
  git add "$file"
done

changed_files이 없을 경우 git add가 제대로 수행되지 않아 발생하는 오류입니다.

```

그래서 changed_files이 있을 때만 git add를 수행하도록 수정했습니다.

```bash
# 변경된 파일들이 있을 경우, 다시 스테이징합니다.
if [ -n "$changed_files" ]; then
  echo "$changed_files" | while IFS= read -r file; do
    git add "$file"
  done
fi
```

## 추가

수정하기는 했는데 husky pre commit 에서 계속 문제가 발생하는 것으로 보아
근본적인 문제는 해결되지 않은 느낌이에요.

이렇게 에러가 발생할 때마다 수정하는 것보다는
문제가 없게끔 명령어를 다시 작성해야 할 것 같습니다.

시간날때 하면 좋을 것 같아요.
