### PR TITLE
refactor: 유저 값 없을 시 로그인페이지로 이동

### DIFF
--- a/src/app/(user)/layout.tsx
+++ b/src/app/(user)/layout.tsx
@@ -1,10 +1,14 @@
 import Navigation from "@/app/(user)/_components/Navigation";
+import Cookies from "js-cookie";
+import { redirect } from "next/navigation";
 
-function UserRootLayout({
-  children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+function UserRootLayout({ children }: { children: React.ReactNode }) {
+  const accessToken = Cookies.get("accessToken");
+
+  if (!accessToken) {
+    redirect("/signin");
+  }
+
   return (
     <div className="relative bg-gray-100">
       <div className="h-100vh fixed inset-0 box-border flex justify-center bg-gray-100 pt-[110px] pc:pt-[75px]">

--- a/src/app/(user)/layout.tsx
+++ b/src/app/(user)/layout.tsx
@@ -2,7 +2,11 @@ import Navigation from "@/app/(user)/_components/Navigation";
 import Cookies from "js-cookie";
 import { redirect } from "next/navigation";
 
-function UserRootLayout({ children }: { children: React.ReactNode }) {
+function UserRootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
   const accessToken = Cookies.get("accessToken");
 
   if (!accessToken) {


### PR DESCRIPTION
## #️⃣연관된 이슈

>ST-75

## 📝작업 내용

> 별다른 기능없이 토큰을 가지고 있지 않을때 (유저정보가 없을때) 내정보 페이지 접속시 로그인페이지로 리다이렉트 시켰습니다
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
