### PR TITLE
chore: 커밋 메세지 제목 제한 50자에서 80자로 늘림 (ST-107)

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -11,8 +11,8 @@ fi
 FIRST_LINE=$(echo "$COMMIT_MESSAGE" | head -n 1)
 FIRST_LINE_LENGTH=$(echo -n "$FIRST_LINE" | wc -m)
 
-if [ "$FIRST_LINE_LENGTH" -gt 50 ]; then
-echo "커밋 메시지의 제목은 50자를 넘을 수 없습니다."
+if [ "$FIRST_LINE_LENGTH" -gt 80 ]; then
+echo "커밋 메시지의 제목은 80자를 넘을 수 없습니다."
 exit 1
 fi
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- ST-107

## 📝작업 내용

커밋 메시지 제목 글자 수가 50자가 넘으면 commit을 push할 수 없도록 husky로 정해져있는데요.

`remove: ShortActivityCard 제거 & ActivityCard로 교체`

이 정도의 글자도 50자가 넘어버리니 커밋을 할 수가 없어서 80자로 올렸으면 좋겠습니다.
