### PR TITLE
feat: 메인페이지 체험섹션 더보기 버튼 추가 (ST-122)

### DIFF
--- a/src/app/_components/ActivitySection.tsx
+++ b/src/app/_components/ActivitySection.tsx
@@ -41,7 +41,7 @@ async function ActivitySection({
       <div className="flex items-center justify-between">
         <h2 className="py-3 text-2lg font-bold text-black">{sectionTitle}</h2>
         <Link
-          className="text-md font-semibold text-primary-500 hover:text-primary-300"
+          className="text-md font-semibold text-primary-500 transition hover:text-primary-300 active:text-primary-200"
           href={`/search?${createQueryString({ category, keyword, sort })}`}
         >
           더보기

--- a/src/app/_components/ActivitySection.tsx
+++ b/src/app/_components/ActivitySection.tsx
@@ -1,6 +1,7 @@
 import activitiesAPI from "@/apis/activitiesAPI";
 import ActivityCard from "@/app/_components/ActivityCard";
 import { Swiper, SwiperContent, SwiperNext, SwiperPrevious } from "@/components/Swiper";
+import createQueryString from "@/utils/createQueryString";
 import Link from "next/link";
 
 interface ActivitySectionProps {
@@ -21,12 +22,14 @@ const categoryTitle = {
 
 async function ActivitySection({
   title: sectionTitle,
-  category,
+  category: categoryKey,
   keyword,
   sort = "most_reviewed",
 }: ActivitySectionProps) {
+  const category = categoryKey && categoryTitle[categoryKey];
+
   const { activities, totalCount } = await activitiesAPI.get({
-    category: category && categoryTitle[category],
+    category,
     keyword,
     sort,
     page: 1,
@@ -37,7 +40,10 @@ async function ActivitySection({
     <section className="flex flex-col">
       <div className="flex items-center justify-between">
         <h2 className="py-3 text-2lg font-bold text-black">{sectionTitle}</h2>
-        <Link className="text-md font-semibold text-primary-500" href="/">
+        <Link
+          className="text-md font-semibold text-primary-500 hover:text-primary-300"
+          href={`/search?${createQueryString({ category, keyword, sort })}`}
+        >
           더보기
         </Link>
       </div>

--- a/src/app/_components/ActivitySection.tsx
+++ b/src/app/_components/ActivitySection.tsx
@@ -35,7 +35,12 @@ async function ActivitySection({
 
   return (
     <section className="flex flex-col">
-      <h2 className="py-3 text-2lg font-bold text-black">{sectionTitle}</h2>
+      <div className="flex items-center justify-between">
+        <h2 className="py-3 text-2lg font-bold text-black">{sectionTitle}</h2>
+        <Link className="text-md font-semibold text-primary-500" href="/">
+          더보기
+        </Link>
+      </div>
 
       {totalCount > 0 ? (
         <Swiper>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -34,7 +34,7 @@ async function SearchPage({ searchParams }: SearchPageProps) {
 
       <section className="flex w-full max-w-[1200px] flex-col gap-3 pb-[100px]">
         <h2 className="text-xl font-bold">
-          &lsquo;{keyword}&rsquo; 검색 결과 {totalCount}개
+          {keyword ? `‘${keyword}’` : "전체"} 검색 결과 {totalCount}개
         </h2>
 
         <div className="flex items-center justify-between">

--- a/src/utils/createQueryString.ts
+++ b/src/utils/createQueryString.ts
@@ -1,0 +1,13 @@
+const createQueryString = (params: Record<string, string | null | undefined>): string => {
+  const queryParams = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      queryParams.set(key, value);
+    }
+  });
+
+  return queryParams.toString();
+};
+
+export default createQueryString;


### PR DESCRIPTION
## #️⃣연관된 이슈

- ST-122

## 📝작업 내용

https://github.com/user-attachments/assets/a10a1a4b-46e1-429e-a8f3-52c954316f5f

메인페이지의 체험섹션은 10개까지만 표시되는데 더보기 버튼 누르면 더 많은 체험들을 볼 수 있도록 검색 페이지로 이동시켜줍니다.

### createQueryString 유틸 함수

query 객체를 받으면 string으로 만들어 변환해주는 함수입니다.

**사용 예시**
```ts
const params = {
  category: "sports",
  keyword: "낚시",
  sort: undefined,
  page: "1",
  size: "10",
};

const query = createQueryString(params);
console.log(query); // 출력: "category=sports&keyword=낚시&page=1&size=10"
```