### PR TITLE
refactor: main page 리액트 쿼리적용(체험 삭제 시, 즉각 반영되게), 모든 페이지 error이미지 처리, 체험관리 예약내역 팝업 수정(ST-163)

### DIFF
--- a/src/app/(home)/_components/ActivityCard.tsx
+++ b/src/app/(home)/_components/ActivityCard.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import useImageError from "@/hooks/useImageError";
 import Image from "next/image";
 import { FaStar } from "react-icons/fa6";
 
@@ -18,12 +21,20 @@ function ActivityCard({
   rating,
   reviewCount,
 }: ActivityCardProps) {
+  const [errorImage] = useImageError(["/images/noImage.png"]);
+
   return (
     <article
       className={`${wide ? "w-full" : "w-[288px] pc:w-full"} relative flex flex-col gap-4 pb-2`}
     >
       <div className="group relative aspect-video w-full overflow-hidden rounded-[10px]">
-        <Image className="object-cover" src={bannerImageUrl} alt="체험 사진" fill />
+        <Image
+          className="object-cover"
+          onError={errorImage.onError}
+          src={errorImage.src || bannerImageUrl}
+          alt="체험 사진"
+          fill
+        />
         <div className="absolute inset-0 bg-black opacity-0 transition-opacity duration-300 ease-in-out group-hover:opacity-20" />
       </div>
       <div className="mx-1 flex flex-col gap-1">

--- a/src/app/(home)/_components/ActivitySection.tsx
+++ b/src/app/(home)/_components/ActivitySection.tsx
@@ -1,7 +1,11 @@
+"use client";
+
 import activitiesAPI from "@/apis/activitiesAPI";
 import ActivityCard from "@/app/(home)/_components/ActivityCard";
+import activitySectionQueryKeys from "@/app/(home)/utils/activitySectionQuery";
 import { Swiper, SwiperContent, SwiperNext, SwiperPrevious } from "@/components/Swiper";
 import createQueryString from "@/utils/createQueryString";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import Link from "next/link";
 
 interface ActivitySectionProps {
@@ -20,7 +24,7 @@ const categoryTitle = {
   wellbeing: "웰빙",
 } as const;
 
-async function ActivitySection({
+function ActivitySection({
   title: sectionTitle,
   category: categoryKey,
   keyword,
@@ -28,13 +32,12 @@ async function ActivitySection({
 }: ActivitySectionProps) {
   const category = categoryKey && categoryTitle[categoryKey];
 
-  const { activities, totalCount } = await activitiesAPI.get({
-    category,
-    keyword,
-    sort,
-    page: 1,
-    size: 10,
+  const { data } = useSuspenseQuery({
+    queryKey: activitySectionQueryKeys.list({ category, keyword, sort, page: 1, size: 10 }),
+    queryFn: () => activitiesAPI.get({ category, keyword, sort, page: 1, size: 10 }),
   });
+
+  const { activities, totalCount } = data || { activities: [], totalCount: 0 };
 
   return (
     <section className="flex flex-col">

--- a/src/app/(home)/_components/BigActivityCard.tsx
+++ b/src/app/(home)/_components/BigActivityCard.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import useImageError from "@/hooks/useImageError";
 import Image from "next/image";
 import { FaStar } from "react-icons/fa6";
 
@@ -18,12 +21,19 @@ function BigActivityCard({
   rating,
   reviewCount,
 }: BigActivityCardProps) {
+  const [errorImage] = useImageError(["/images/noImage.png"]);
   return (
     <article
       className={`${wide ? "w-full" : "w-[288px] pc:w-full"} group relative flex aspect-square flex-col justify-end overflow-hidden rounded-[10px] p-5`}
     >
       <div>
-        <Image className="object-cover" src={bannerImageUrl} alt="체험 사진" fill />
+        <Image
+          className="object-cover"
+          onError={errorImage.onError}
+          src={errorImage.src || bannerImageUrl}
+          alt="체험 사진"
+          fill
+        />
         <div className="absolute inset-0 bg-black opacity-30 transition-opacity duration-300 ease-in-out group-hover:opacity-50" />
       </div>
       <div className="z-10 mx-1 flex flex-col gap-2 text-white">

--- a/src/app/(home)/_components/BigActivitySection.tsx
+++ b/src/app/(home)/_components/BigActivitySection.tsx
@@ -1,6 +1,10 @@
+"use client";
+
 import activitiesAPI from "@/apis/activitiesAPI";
 import BigActivityCard from "@/app/(home)/_components/BigActivityCard";
+import activitySectionQueryKeys from "@/app/(home)/utils/activitySectionQuery";
 import { Swiper, SwiperContent, SwiperNext, SwiperPrevious } from "@/components/Swiper";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import Link from "next/link";
 
 interface BigActivitySectionProps {
@@ -19,19 +23,31 @@ const categoryTitle = {
   wellbeing: "웰빙",
 } as const;
 
-async function BigActivitySection({
+function BigActivitySection({
   title: sectionTitle,
   category,
   keyword,
   sort = "most_reviewed",
 }: BigActivitySectionProps) {
-  const { activities, totalCount } = await activitiesAPI.get({
-    category: category && categoryTitle[category],
-    keyword,
-    sort,
-    page: 1,
-    size: 10,
+  const { data } = useSuspenseQuery({
+    queryKey: activitySectionQueryKeys.list({
+      category: category && categoryTitle[category],
+      keyword,
+      sort,
+      page: 1,
+      size: 10,
+    }),
+    queryFn: () =>
+      activitiesAPI.get({
+        category: category && categoryTitle[category],
+        keyword,
+        sort,
+        page: 1,
+        size: 10,
+      }),
   });
+
+  const { activities, totalCount } = data || { activities: [], totalCount: 0 };
 
   return (
     <section className="flex flex-col">

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,39 +1,51 @@
+import activitiesAPI from "@/apis/activitiesAPI";
 import ActivitySection from "@/app/(home)/_components/ActivitySection";
 import Banner from "@/app/(home)/_components/Banner";
 import BigActivitySection from "@/app/(home)/_components/BigActivitySection";
 import SearchForm from "@/app/(home)/_components/SearchForm";
+import activitySectionQueryKeys from "@/app/(home)/utils/activitySectionQuery";
 import LoadingSpinner from "@/utils/LoadingSpinnter";
+import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
 import { Suspense } from "react";
 
-function Home() {
-  return (
-    <Suspense fallback={<LoadingSpinner />}>
-      <main className="flex flex-col items-center">
-        <div className="relative flex w-full">
-          <Banner />
+async function Home() {
+  const queryClient = new QueryClient();
 
-          <div className="absolute bottom-16 flex w-full justify-center px-5 pc:px-10">
-            <div className="flex w-full max-w-[1200px] flex-col gap-5 rounded-2xl bg-white p-5">
-              <h2 className="text-2lg font-bold">무엇을 체험하고 싶으신가요?</h2>
-              <SearchForm placeholder="내가 원하는 체험은" />
+  await queryClient.prefetchQuery({
+    queryKey: activitySectionQueryKeys.list({ sort: "most_reviewed", page: 1, size: 999 }),
+    queryFn: () => activitiesAPI.get({ sort: "most_reviewed", page: 1, size: 999 }),
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <Suspense fallback={<LoadingSpinner />}>
+        <main className="flex flex-col items-center">
+          <div className="relative flex w-full">
+            <Banner />
+
+            <div className="absolute bottom-16 flex w-full justify-center px-5 pc:px-10">
+              <div className="flex w-full max-w-[1200px] flex-col gap-5 rounded-2xl bg-white p-5">
+                <h2 className="text-2lg font-bold">무엇을 체험하고 싶으신가요?</h2>
+                <SearchForm placeholder="내가 원하는 체험은" />
+              </div>
             </div>
           </div>
-        </div>
 
-        <div className="flex w-full justify-center px-5 pc:px-10">
-          <div className="mb-[100px] mt-[50px] flex w-full max-w-[1200px] flex-col gap-5 tablet:gap-10">
-            <BigActivitySection title="실시간 인기 체험 🔥" sort="most_reviewed" />
-            <ActivitySection title="새로 오픈한 체험 🆕" sort="latest" />
-            <ActivitySection title="일상을 풍요롭게 만드는 특별한 경험 🎨🎶" category="arts" />
-            <ActivitySection title="입맛을 사로잡는 미식 여행 🍽️" category="food" />
-            <ActivitySection title="에너지 넘치는 스포츠 체험 ⚽" category="sports" />
-            <ActivitySection title="일상 밖의 모험, 숨은 명소로의 초대장 💌" category="tour" />
-            <ActivitySection title="웰빙으로 건강한 일상 만들기 🌱" category="wellbeing" />
-            <ActivitySection title="손끝에 전해지는 짜릿한 손맛! 🐟" keyword="낚시" />
+          <div className="flex w-full justify-center px-5 pc:px-10">
+            <div className="mb-[100px] mt-[50px] flex w-full max-w-[1200px] flex-col gap-5 tablet:gap-10">
+              <BigActivitySection title="실시간 인기 체험 🔥" sort="most_reviewed" />
+              <ActivitySection title="새로 오픈한 체험 🆕" sort="latest" />
+              <ActivitySection title="일상을 풍요롭게 만드는 특별한 경험 🎨🎶" category="arts" />
+              <ActivitySection title="입맛을 사로잡는 미식 여행 🍽️" category="food" />
+              <ActivitySection title="에너지 넘치는 스포츠 체험 ⚽" category="sports" />
+              <ActivitySection title="일상 밖의 모험, 숨은 명소로의 초대장 💌" category="tour" />
+              <ActivitySection title="웰빙으로 건강한 일상 만들기 🌱" category="wellbeing" />
+              <ActivitySection title="손끝에 전해지는 짜릿한 손맛! 🐟" keyword="낚시" />
+            </div>
           </div>
-        </div>
-      </main>
-    </Suspense>
+        </main>
+      </Suspense>
+    </HydrationBoundary>
   );
 }
 

--- a/src/app/(home)/utils/activitySectionQuery.ts
+++ b/src/app/(home)/utils/activitySectionQuery.ts
@@ -1,0 +1,12 @@
+const activitySectionQueryKeys = {
+  all: ["activities"] as const,
+  list: (filters: {
+    category?: string;
+    keyword?: string;
+    sort: string;
+    page: number;
+    size: number;
+  }) => [...activitySectionQueryKeys.all, "list", filters] as const,
+};
+
+export default activitySectionQueryKeys;

--- a/src/app/(user)/myactivities/_components/MyActivityItem.tsx
+++ b/src/app/(user)/myactivities/_components/MyActivityItem.tsx
@@ -3,6 +3,7 @@
 import { Activities } from "@/apis/API.type";
 import myActivitiesAPI from "@/apis/myActivitiesAPI";
 import Popup, { closePopup } from "@/components/Popup";
+import useImageError from "@/hooks/useImageError";
 import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
@@ -12,6 +13,7 @@ import ContextMenu from "./ContextMenu";
 
 function MyActivityItem({ activity }: { activity: Activities }) {
   const [isOpen, setIsOpen] = useState(false);
+  const [errorImage] = useImageError(["/images/noImage.png"]);
 
   const handleClickMore = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -28,9 +30,10 @@ function MyActivityItem({ activity }: { activity: Activities }) {
         <div className="relative aspect-square h-32 w-32 overflow-hidden rounded-l-[24px] tablet:h-[156px] tablet:w-[156px] pc:h-[204px] pc:w-[204px]">
           <Link href={`/${activity.id}`}>
             <Image
-              src={activity.bannerImageUrl}
+              src={errorImage.src || activity.bannerImageUrl}
               fill
               alt="배너 이미지"
+              onError={errorImage.onError}
               className="rounded-l-[24px] object-cover transition hover:scale-110"
             />
           </Link>

--- a/src/app/(user)/myactivities/_components/MyActivityItem.tsx
+++ b/src/app/(user)/myactivities/_components/MyActivityItem.tsx
@@ -64,7 +64,7 @@ function MyActivityItem({ activity }: { activity: Activities }) {
       </div>
       <Popup
         id="cancel"
-        text="예약을 취소하시겠어요?"
+        text="소중한 체험을 삭제하시겠습니까?"
         leftButton="아니요"
         onChangeLeftButton={() => closePopup("cancel")}
         rightButton="네"

--- a/src/app/(user)/reservations/_components/MyReservationItem.tsx
+++ b/src/app/(user)/reservations/_components/MyReservationItem.tsx
@@ -128,11 +128,11 @@ function MyReservationItem({
         </div>
         <Popup
           id={`cancel-${reservationState.id}`}
-          text="예약을 취소하겠어요?"
-          leftButton="취소하기"
-          onChangeLeftButton={handleCancelReservation}
-          rightButton="아니요"
-          onChangeRightButton={() => closePopup(`cancel-${reservationState.id}`)}
+          text="예약을 취소 하시겠습니까?"
+          leftButton="아니요"
+          onChangeLeftButton={() => closePopup(`cancel-${reservationState.id}`)}
+          rightButton="취소하기"
+          onChangeRightButton={handleCancelReservation}
         />
       </div>
     </div>

--- a/src/app/(user)/reservations/_components/MyReservationItem.tsx
+++ b/src/app/(user)/reservations/_components/MyReservationItem.tsx
@@ -5,6 +5,7 @@ import myReservationAPI from "@/apis/myReservationAPI";
 import { Button } from "@/components/Button";
 import Modal, { openModal } from "@/components/Modal";
 import Popup, { closePopup, openPopup } from "@/components/Popup";
+import useImageError from "@/hooks/useImageError";
 import useMediaQuery from "@/hooks/useMediaQuery";
 import Image from "next/image";
 import Link from "next/link";
@@ -19,6 +20,7 @@ function MyReservationItem({
   reservation: Reservations;
   statusTitle: string;
 }) {
+  const [errorImage] = useImageError(["/images/noImage.png"]);
   const { isMobile, isTablet, isPc } = useMediaQuery();
   const [reservationState, setReservationState] = useState(reservation);
 
@@ -72,11 +74,12 @@ function MyReservationItem({
             className="mt-[8px] text-[20px] font-bold hover:underline"
           >
             <Image
-              src={reservation.activity.bannerImageUrl}
+              src={errorImage.src || reservation.activity.bannerImageUrl}
               alt="액티비티 사진"
               fill
               objectFit="cover"
               className="transition hover:scale-110"
+              onError={errorImage.onError}
             />
           </Link>
         </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ST-163

## 📝작업 내용

> 리액트 쿼리를 적용해서 삭제 등록 시에도 즉각 반영되게 수정했습니다. 그리고 모든 페이지 엑박 에러들을 기본 이미지가 뜨게 대처하고, 체험관리 예약내역 팝업 버튼 위치 좌우 변경 그리고 text도 수정했습니다.

### 스크린샷 (선택)

https://github.com/user-attachments/assets/591e3a12-abc3-4f8a-b343-8c172224cc5d


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
