### PR TITLE
fix: Images => img태그로 대체(ST-184)

### DIFF
--- a/src/app/(home)/[activityId]/_components/Images.tsx
+++ b/src/app/(home)/[activityId]/_components/Images.tsx
@@ -6,6 +6,8 @@ import { FaChevronLeft, FaChevronRight } from "react-icons/fa6";
 
 import useImageError from "@/hooks/useImageError";
 
+import Picture from "@/components/Picture";
+
 import useGetActivityImageViewModel from "../_hooks/useGetActivityImagesViewModel";
 
 const showImage = [
@@ -38,14 +40,14 @@ function Images() {
   return (
     <div className="-mx-6 flex justify-center tablet:mx-[0.5px] tablet:justify-normal tablet:gap-1 pc:gap-2">
       <div className={`relative h-[310px] ${mainImageClasses} pc:h-[534px]`}>
-        <Image
+        <Picture
           src={errorImage.src || totalImages[imageIndex]}
           alt={`${title} 배경 사진`}
           fill
           style={{
             objectFit: "cover",
           }}
-          onError={errorImage.onError}
+          priority
         />
         <button
           type="button"

--- a/src/app/(home)/_components/ActivityCard.tsx
+++ b/src/app/(home)/_components/ActivityCard.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import Image from "next/image";
 import { FaStar } from "react-icons/fa6";
 
-import useImageError from "@/hooks/useImageError";
+import Picture from "@/components/Picture";
 
 interface ActivityCardProps {
   wide?: boolean;
@@ -22,20 +21,12 @@ function ActivityCard({
   rating,
   reviewCount,
 }: ActivityCardProps) {
-  const [errorImage] = useImageError(["/images/noImage.png"]);
-
   return (
     <article
       className={`${wide ? "w-full" : "w-[288px] pc:w-full"} relative flex flex-col gap-4 pb-2`}
     >
       <div className="group relative aspect-video w-full overflow-hidden rounded-[10px]">
-        <Image
-          className="object-cover"
-          onError={errorImage.onError}
-          src={errorImage.src || bannerImageUrl}
-          alt="체험 사진"
-          fill
-        />
+        <Picture className="object-cover" src={bannerImageUrl} alt="체험 사진" fill />
         <div className="absolute inset-0 bg-black opacity-0 transition-opacity duration-300 ease-in-out group-hover:opacity-20" />
       </div>
       <div className="mx-1 flex flex-col gap-1">

--- a/src/app/(home)/_components/BigActivityCard.tsx
+++ b/src/app/(home)/_components/BigActivityCard.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import Image from "next/image";
 import { FaStar } from "react-icons/fa6";
 
-import useImageError from "@/hooks/useImageError";
+import Picture from "@/components/Picture";
 
 interface BigActivityCardProps {
   wide?: boolean;
@@ -22,19 +21,12 @@ function BigActivityCard({
   rating,
   reviewCount,
 }: BigActivityCardProps) {
-  const [errorImage] = useImageError(["/images/noImage.png"]);
   return (
     <article
       className={`${wide ? "w-full" : "w-[288px] pc:w-full"} group relative flex aspect-square flex-col justify-end overflow-hidden rounded-[10px] p-5`}
     >
       <div>
-        <Image
-          className="object-cover"
-          onError={errorImage.onError}
-          src={errorImage.src || bannerImageUrl}
-          alt="체험 사진"
-          fill
-        />
+        <Picture className="object-cover" src={bannerImageUrl} alt="체험 사진" fill />
         <div className="absolute inset-0 bg-black opacity-30 transition-opacity duration-300 ease-in-out group-hover:opacity-50" />
       </div>
       <div className="z-10 mx-1 flex flex-col gap-2 text-white">

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -31,7 +31,6 @@ async function Home() {
             </div>
           </div>
         </section>
-
         <BigActivitySection title="실시간 인기 체험 🔥" sort="most_reviewed" />
         <ActivitySection title="새로 오픈한 체험 🆕" sort="latest" />
         <ActivitySection title="일상을 풍요롭게 만드는 특별한 경험 🎨🎶" category="arts" />

--- a/src/app/(user)/myactivities/_components/MyActivities.tsx
+++ b/src/app/(user)/myactivities/_components/MyActivities.tsx
@@ -8,6 +8,7 @@ import { getActivitiesRes } from "@/apis/API.type";
 import myActivitiesAPI from "@/apis/myActivitiesAPI";
 
 import { LinkButton } from "@/components/Button";
+import Picture from "@/components/Picture";
 
 import LoadingSpinner from "@/utils/LoadingSpinnter";
 
@@ -62,6 +63,7 @@ function MyActivities() {
       ) : (
         <div className="flex h-full w-full flex-col items-center justify-center">
           <Image src="/images/empty.png" alt="빈 이미지" width={240} height={240} />
+          <Picture src="/images/empty.png" alt="빈 이미지" width={240} height={240} />
           <p className="text-xl font-medium text-gray-500">아직 등록한 체험이 없어요</p>
         </div>
       )}

--- a/src/app/(user)/reservations/_components/MyReservations.tsx
+++ b/src/app/(user)/reservations/_components/MyReservations.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { InfiniteData, useInfiniteQuery } from "@tanstack/react-query";
-import Image from "next/image";
 import { useCallback, useState } from "react";
 
 import { ReservationRes } from "@/apis/API.type";
 import myReservationAPI from "@/apis/myReservationAPI";
+
+import Picture from "@/components/Picture";
 
 import LoadingSpinner from "@/utils/LoadingSpinnter";
 
@@ -75,7 +76,7 @@ function MyReservations() {
         </div>
       ) : (
         <div className="flex w-full grow flex-col items-center justify-center">
-          <Image src="/images/empty.png" alt="빈 이미지" width={240} height={240} />
+          <Picture src="/images/empty.png" alt="빈 이미지" width={240} height={240} />
           <p className="text-2xl font-medium text-gray-500">아직 예약한 체험이 없어요</p>
         </div>
       )}

--- a/src/app/(user)/reservations/_components/review/Review.tsx
+++ b/src/app/(user)/reservations/_components/review/Review.tsx
@@ -1,10 +1,10 @@
-import Image from "next/image";
 import { useState } from "react";
 
 import { Reservations } from "@/apis/API.type";
 import myReservationAPI from "@/apis/myReservationAPI";
 
 import { Button } from "@/components/Button";
+import Picture from "@/components/Picture";
 
 import Rating from "./Rating";
 
@@ -18,7 +18,7 @@ function Review({ reservation }: { reservation: Reservations }) {
   return (
     <div className="flex h-full w-[100vw] flex-col gap-3 px-4 tablet:w-[460px] tablet:gap-6 tablet:px-6">
       <div className="flex h-[100px] items-center gap-2 tablet:h-[137px]">
-        <Image
+        <Picture
           src={reservation.activity.bannerImageUrl}
           width={100}
           height={100}

--- a/src/app/_components/Header/UserPopover.tsx
+++ b/src/app/_components/Header/UserPopover.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import Image from "next/image";
 import { useRouter } from "next/navigation";
 
+import Picture from "@/components/Picture";
 import { Popover, PopoverContent, PopoverItem, PopoverTrigger } from "@/components/Popover";
 
 import socialLoginStore from "@/store/socialLoginStore";
@@ -35,12 +35,13 @@ function UserPopover() {
       <PopoverTrigger>
         <div className="flex items-center gap-2 rounded-lg transition-colors tablet:px-2 tablet:py-[6px] tablet:hover:bg-gray-100 tablet:active:bg-gray-200">
           <div className="relative h-7 w-7 overflow-hidden rounded-full transition hover:opacity-60 tablet:hover:opacity-100">
-            <Image
+            <Picture
               className="object-cover"
               src={userInfo?.profileImageUrl || "/icons/profile.svg"}
               alt="프로필 사진"
               draggable={false}
               fill
+              priority
             />
           </div>
           <p className="hidden max-w-[60px] truncate text-left text-md font-normal tablet:block">

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -1,4 +1,6 @@
-import React from "react";
+"use client";
+
+import useImageError from "@/hooks/useImageError";
 
 interface PictureProps {
   src: string;
@@ -7,21 +9,33 @@ interface PictureProps {
   height?: number;
   className?: string;
   loading?: "lazy" | "eager";
+  style?: React.CSSProperties;
+  errorSrc?: string;
+  priority?: boolean;
+  fill?: boolean;
+  draggable?: boolean;
 }
 
-function Picture({ src, alt, width, height, className, loading = "lazy" }: PictureProps) {
+function Picture({ src, priority, fill, style, errorSrc, ...props }: PictureProps) {
+  const [errorImage] = useImageError(["/images/noImage.png"] || errorSrc);
+
   return (
     <img
-      src={src}
-      alt={alt}
-      width={width}
-      height={height}
-      className={className}
-      loading={loading}
+      src={errorImage.src || src}
+      loading={priority ? "eager" : props.loading || "lazy"}
       style={{
-        maxWidth: "100%",
-        height: "auto",
+        width: fill ? "100%" : undefined,
+        height: fill ? "100%" : undefined,
+        position: fill ? "absolute" : undefined,
+        objectFit: fill ? "cover" : undefined,
+        left: fill ? "50%" : undefined,
+        top: fill ? "50%" : undefined,
+        transform: fill ? "translate(-50%, -50%)" : undefined,
+        ...style,
       }}
+      draggable={props.draggable ?? true}
+      onError={errorImage.onError}
+      {...props}
     />
   );
 }

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+interface PictureProps {
+  src: string;
+  alt: string;
+  width?: number;
+  height?: number;
+  className?: string;
+  loading?: "lazy" | "eager";
+}
+
+function Picture({ src, alt, width, height, className, loading = "lazy" }: PictureProps) {
+  return (
+    <img
+      src={src}
+      alt={alt}
+      width={width}
+      height={height}
+      className={className}
+      loading={loading}
+      style={{
+        maxWidth: "100%",
+        height: "auto",
+      }}
+    />
+  );
+}
+
+export default Picture;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ST-184

## 📝작업 내용

> 기존에 있던 Image태그를 쓴 것중 사용자가 늘어남에 따라 엄청난 캐싱이 우려되는 것들은 모두 img태그를 커스텀한 Picture 컴포넌트로 바꿨습니다. 각 자 맡은 페이지 변경점 봐주시면 감사하겠습니다!
### 스크린샷 (선택)
**고치고 있는 문제가있는데, 봐주시면 좋겠습니다..**

https://github.com/user-attachments/assets/90d0fe80-0fee-4819-be4e-3aa2d5e850b6

에러 이미지일 시 noImage로 대체를 잘 하는데, 새로고침을 하면 초기화가 되버립니다..
기존에는 잘 작동하던게 img태그로 대체하고부터는 안돼요.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
